### PR TITLE
Develop

### DIFF
--- a/chrome/content/imglikeopera.js
+++ b/chrome/content/imglikeopera.js
@@ -653,6 +653,6 @@ var ILO = {
   }
 };
 
-window.addEventListener("load", function() ILO.onLoad(), false);
-window.addEventListener("unload", function() ILO.unLoad(), false);
+window.addEventListener("load", function(){ILO.onLoad();}, false);
+window.addEventListener("unload", function(){ILO.unLoad();}, false);
 window.addEventListener("delayLoadRefresher", ILO, false);

--- a/chrome/content/preferences/filters.js
+++ b/chrome/content/preferences/filters.js
@@ -30,7 +30,7 @@ const Filters = {
     this.rButtons =   document.getElementById("iloPermButtons").childNodes;
     this.rPopup =     document.getElementById("iloFiltersPopup").childNodes;
     
-    let policyPatternsData = (this.settings.policy_patterns || []).split("  ");
+    let policyPatternsData = (this.settings.policy_patterns || []).toString().split("  ");
     for (let i = 0, len = policyPatternsData.length - 1; i < len; i++)
       this.treeAddItem(policyPatternsData[i].split(" "));
   },

--- a/chrome/content/preferences/filters.js
+++ b/chrome/content/preferences/filters.js
@@ -449,3 +449,9 @@ const Filters = {
             select[0]];
   }
 };
+
+Object.defineProperty(this, "Filters", {
+  value: Filters,
+  enumerable: true,
+  writable: false
+});

--- a/chrome/content/preferences/preferences.js
+++ b/chrome/content/preferences/preferences.js
@@ -128,8 +128,8 @@ const Preferences = {
       let actualValue = typeof preference.value != "undefined" ? preference.value : preference.defaultValue;
       let modesValue = (actualValue || "1,2,3,4")
                          .split(",")
-                         .map(function(mode) parseInt(mode, 10))
-                         .filter(function(mode) mode >= 1 && mode <= 4)
+                         .map(function(mode) {parseInt(mode, 10)})
+                         .filter(function(mode) {mode >= 1 && mode <= 4})
                          .sort();
       
       if (!modesValue.length)
@@ -157,6 +157,12 @@ const Preferences = {
     }
   }
 };
+
+Object.defineProperty(this, "Preferences", {
+  value: Preferences,
+  enumerable: true,
+  writable: false
+});
 
 window.addEventListener("load", Preferences, false);
 window.addEventListener("paneload", Preferences, false);

--- a/install.rdf
+++ b/install.rdf
@@ -35,7 +35,17 @@
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-        <em:minVersion>19.0</em:minVersion>
+        <em:minVersion>38.0</em:minVersion>
+        <em:maxVersion>56.*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+
+    <!-- PaleMoon -->
+    <em:targetApplication>
+      <Description>
+        <em:id>{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}</em:id>
+        <em:minVersion>26.0</em:minVersion>
+        <em:maxVersion>28.*</em:maxVersion>
       </Description>
     </em:targetApplication>
 

--- a/modules/AddonManager.jsm
+++ b/modules/AddonManager.jsm
@@ -18,15 +18,15 @@ const AddonManager = {
       //   > 0 - curent > last
       addonVersionState: 0,
       // Is version changed?
-      get addonVersionChanged() this.addonVersionState != 0,
+      get addonVersionChanged() {return this.addonVersionState != 0;},
       // ...up?
-      get addonUpgraded() this.addonVersionState > 0,
+      get addonUpgraded() {return this.addonVersionState > 0;},
       // ...or down?
-      get addonDowngraded() this.addonVersionState < 0,
+      get addonDowngraded() {return this.addonVersionState < 0;},
       // Previous version.
       addonLastVersion: "0",
       // true == "fresh" install.
-      get freshInstall() this.addonLastVersion === "0"
+      get freshInstall() {return this.addonLastVersion === "0";}
     };
     
     this._start();

--- a/modules/DocumentData.jsm
+++ b/modules/DocumentData.jsm
@@ -1,6 +1,6 @@
 "use strict";
 
-let EXPORTED_SYMBOLS = ["DocumentData"];
+var EXPORTED_SYMBOLS = ["DocumentData"];
 
 function DocumentData(aTab, aDelay) {
   this.clearURLStatus();

--- a/modules/FileUtils.jsm
+++ b/modules/FileUtils.jsm
@@ -1,6 +1,6 @@
 "use strict";
 
-let EXPORTED_SYMBOLS = ["FileUtils"];
+var EXPORTED_SYMBOLS = ["FileUtils"];
 
 const {
   classes: Cc,

--- a/modules/Preferences.jsm
+++ b/modules/Preferences.jsm
@@ -35,7 +35,7 @@
  *
  * ***** END LICENSE BLOCK ***** */
 
-let EXPORTED_SYMBOLS = ["Preferences", "Prefs"];
+var EXPORTED_SYMBOLS = ["Preferences", "Prefs"];
 
 const Cc = Components.classes;
 const Ci = Components.interfaces;
@@ -76,7 +76,7 @@ Preferences.prototype = {
    */
   get: function(prefName, defaultValue) {
     if (isArray(prefName))
-      return prefName.map(function(v) this.get(v, defaultValue), this);
+      return prefName.map(function(v) {return this.get(v, defaultValue);}, this);
 
     if (this._site)
       return this._siteGet(prefName, defaultValue);
@@ -106,7 +106,7 @@ Preferences.prototype = {
     }
   },
 
-  get prefBranch() this._prefBranch,
+  get prefBranch() {return this._prefBranch;},
 
   _siteGet: function(prefName, defaultValue) {
     let value = this._contentPrefSvc.getPref(this._site, this._prefBranch + prefName);
@@ -278,11 +278,11 @@ Preferences.prototype = {
    * which is equivalent.
    * @deprecated
    */
-  modified: function(prefName) { return this.isSet(prefName) },
+  modified: function(prefName) { return this.isSet(prefName); },
 
   reset: function(prefName) {
     if (isArray(prefName)) {
-      prefName.map(function(v) this.reset(v), this);
+      prefName.map(function(v) {return this.reset(v);}, this);
       return;
     }
 
@@ -414,9 +414,9 @@ Preferences.prototype = {
     // make it.  We could index by fullBranch, but we can't index by callback
     // or thisObject, as far as I know, since the keys to JavaScript hashes
     // (a.k.a. objects) can apparently only be primitive values.
-    let [observer] = observers.filter(function(v) v.prefName   == fullPrefName &&
+    let [observer] = observers.filter(function(v) {return v.prefName   == fullPrefName &&
                                                   v.callback   == callback &&
-                                                  v.thisObject == thisObject);
+                                                  v.thisObject == thisObject;});
 
     if (observer) {
       Preferences._prefSvc.removeObserver(fullPrefName, observer);
@@ -459,7 +459,7 @@ Preferences.prototype = {
                   getService(Ci.nsIPrefService).
                   getBranch(this._prefBranch).
                   QueryInterface(Ci.nsIPrefBranch2);
-    this.__defineGetter__("_prefSvc", function() prefSvc);
+    this.__defineGetter__("_prefSvc", function() {return prefSvc;});
     return this._prefSvc;
   },
 
@@ -470,7 +470,7 @@ Preferences.prototype = {
   get _ioSvc() {
     let ioSvc = Cc["@mozilla.org/network/io-service;1"].
                 getService(Ci.nsIIOService);
-    this.__defineGetter__("_ioSvc", function() ioSvc);
+    this.__defineGetter__("_ioSvc", function() {return ioSvc;});
     return this._ioSvc;
   },
 
@@ -481,7 +481,7 @@ Preferences.prototype = {
   get _contentPrefSvc() {
     let contentPrefSvc = Cc["@mozilla.org/content-pref/service;1"].
                          getService(Ci.nsIContentPrefService);
-    this.__defineGetter__("_contentPrefSvc", function() contentPrefSvc);
+    this.__defineGetter__("_contentPrefSvc", function() {return contentPrefSvc;});
     return this._contentPrefSvc;
   }
 
@@ -575,9 +575,9 @@ Preferences.prototype.observe2 = function(prefName, callback, thisObject) {
 
 Preferences.prototype.ignore2 = function(prefName, callback, thisObject) {
   let fullPrefName = this._prefBranch + (prefName || "");
-  let [observer] = observers2.filter(function(v) v.prefName   == fullPrefName &&
+  let [observer] = observers2.filter(function(v) {return v.prefName   == fullPrefName &&
                                                  v.callback   == callback &&
-                                                 v.thisObject == thisObject);
+                                                 v.thisObject == thisObject;});
 
   if (observer) {
     Preferences._prefSvc.removeObserver(fullPrefName, observer);

--- a/modules/Settings.jsm
+++ b/modules/Settings.jsm
@@ -1,6 +1,6 @@
 "use strict";
 
-let EXPORTED_SYMBOLS = ["Settings"];
+var EXPORTED_SYMBOLS = ["Settings"];
 
 Components.utils.import("resource://imglikeopera-modules/Preferences.jsm");
 
@@ -12,7 +12,7 @@ Components.utils.import("resource://imglikeopera-modules/Preferences.jsm");
 
 /************************************************************************/
 
-let Settings = Proxy.create({
+var Settings = new Proxy({}, {
   get: function SettingsProxy_get(aProxy, aName) {
     let prefName = propName2prefName(aName);
     
@@ -51,5 +51,5 @@ Prefs.observe2("", settingsObserver);
 
 /************************************************************************/
 
-function prefName2propName(str) str.replace(/\./g, "_");
-function propName2prefName(str) str.replace(/_/g, ".");
+function prefName2propName(str) {return str.replace(/\./g, "_");}
+function propName2prefName(str) {return str.replace(/_/g, ".");}


### PR DESCRIPTION
Now add-on works with **Firefox 38-56** and **Palemoon 26-28**!

Code syntax was checked with ES6 Syntax checker, removed deprecated Proxy api, defineGetter and other errors and warnings. Implemented iumo's let/const and Firefox cache v2 fixes.